### PR TITLE
Fix groth16.hpp multiple includes

### DIFF
--- a/src/groth16.hpp
+++ b/src/groth16.hpp
@@ -1,3 +1,6 @@
+#ifndef GROTH16_HPP
+#define GROTH16_HPP
+
 #include <string>
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
@@ -120,3 +123,5 @@ namespace Groth16 {
 
 
 #include "groth16.cpp"
+
+#endif

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -52,10 +52,16 @@ Logger::Logger()
    InitializeCriticalSection(&m_Mutex);
 #else
    int ret=0;
+   ret = pthread_mutexattr_init(&m_Attr); // TODO: Pull request - Add this change to the common repo
+   if (ret != 0)
+   {
+      printf("Logger::Logger() -- Mutex attribute could not initialize!!\n");
+      exit(0);
+   }
    ret = pthread_mutexattr_settype(&m_Attr, PTHREAD_MUTEX_ERRORCHECK_NP);
    if(ret != 0)
    {   
-      printf("Logger::Logger() -- Mutex attribute not initialize!!\n");
+      printf("Logger::Logger() -- Mutex attribute could not set type!!\n");
       exit(0);
    }   
    ret = pthread_mutex_init(&m_Mutex,&m_Attr);


### PR DESCRIPTION
Fix multple includes of groth16.hpp, i.e. protect with an #ifndef ... #def ... #endif precompiler directive.