### PR TITLE
taskfile: Add support for building static binary

### DIFF
--- a/tasksfile.js
+++ b/tasksfile.js
@@ -1,4 +1,4 @@
-const { sh, cli } = require("tasksfile");
+const { sh, cli, rawArgs } = require("tasksfile");
 
 function cleanAll() {
     sh("rm -rf build");
@@ -33,7 +33,8 @@ function buildPistche() {
 
 function buildProverServer() {
     sh("cp " + process.argv[3] + " build/circuit.cpp", {cwd: ".", nopipe: true});
-    sh("g++" +
+    sh("g++ " +
+        rawArgs()+
         " -I."+
         " -I../src"+
         " -I../depends/pistache/include"+
@@ -65,7 +66,8 @@ function buildProverServer() {
 
 
 function buildProver() {
-    sh("g++" +
+    sh("g++ " +
+        rawArgs()+
         " -I."+
         " -I../src"+
         " -I../depends/ffiasm/c"+


### PR DESCRIPTION
Sometimes it's nice to have a static binary which can be ported to other
system. Thus, let's add a special flag for it.

> npx task buildProver -static

> file ./build/prover
./build/prover: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked
, BuildID[sha1]=2a3cf55bdb2a7b7fa463ac76f462307f603f5f9d, for GNU/Linux 3.2.0, not stripped

Signed-off-by: Jinank Jain <jinank94@gmail.com>