### PR TITLE
feat: prover server for multiple circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You have an example of the usage calling the server endpoints to generate the pr
 
 To test a request you should pass an `input.json` as a parameter to the request call.
 ````sh
-node tools/request.js ./input.json
+node tools/request.js <input.json> <circuit>
 ````
 ## Benchmark
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 rapid snark is a zkSnark proof generation written in C++ and intel assembly. That generates proofs created in [circom](https://github.com/iden3/snarkjs) and [snarkjs](https://github.com/iden3/circom) very fast.
 
-## dependencies
+## Dependencies
 
 You should have installed gcc, libsodium, and gmp (development)
 
@@ -15,7 +15,7 @@ sudo apt-get install libsodium-dev
 sudo apt-get install nasm
 ````
 
-## compile prover
+## Compile prover in standalone mode
 
 ````sh
 npm install
@@ -23,6 +23,17 @@ git submodule init
 git submodule update
 npx task createFieldSources
 npx task buildProver
+````
+
+## Compile prover in server mode
+
+````sh
+npm install
+git submodule init
+git submodule update
+npx task createFieldSources
+npx task buildPistache
+npx task buildProverServer
 ````
 
 ## Building proof
@@ -37,9 +48,18 @@ snarkjs groth16 prove <circuit.zkey> <witness.wtns> <proof.json> <public.json>
 
 by this one
 ````sh
-./build/prove <circuit.zkey> <witness.wtns> <proof.json> <public.json>
+./build/prover <circuit.zkey> <witness.wtns> <proof.json> <public.json>
 ````
+## Launch prover in server mode
+````sh
+./build/proverServer  <port> <circuit1_zkey> <circuit2_zkey> ... <circuitN_zkey>
+````
+You have an example of the usage calling the server endpoints to generate the proof with Nodejs in `/tools/request.js`.
 
+To test a request you should pass an `input.json` as a parameter to the request call.
+````sh
+node tools/request.js ./input.json
+````
 ## Benchmark
 
 This prover uses intel assembly with ADX extensions and parallelizes as much as it can the proof generation. 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ by this one
 ````sh
 ./build/proverServer  <port> <circuit1_zkey> <circuit2_zkey> ... <circuitN_zkey>
 ````
-For every `circuit.circom` you have to compile de `circuit_cpp` generated with circom and copy the executable into the `build` folder so the server can generate the witness and then the proof based on this witness.
+For every `circuit.circom` you have to generate with circom with --c option the `circuit_cpp` and after compilation you have to copy the executable into the `build` folder so the server can generate the witness and then the proof based on this witness.
 You have an example of the usage calling the server endpoints to generate the proof with Nodejs in `/tools/request.js`.
 
 To test a request you should pass an `input.json` as a parameter to the request call.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ by this one
 ````sh
 ./build/proverServer  <port> <circuit1_zkey> <circuit2_zkey> ... <circuitN_zkey>
 ````
+For every `circuit.circom` you have to compile de `circuit_cpp` generated with circom and copy the executable into the `build` folder so the server can generate the witness and then the proof based on this witness.
 You have an example of the usage calling the server endpoints to generate the proof with Nodejs in `/tools/request.js`.
 
 To test a request you should pass an `input.json` as a parameter to the request call.

--- a/src/fullprover.hpp
+++ b/src/fullprover.hpp
@@ -17,6 +17,8 @@ class FullProver {
 
     std::string pendingInput;
     std::string executingInput;
+    std::string pendingCircuit;
+    std::string executingCircuit;
 
     std::map<std::string, std::unique_ptr<Groth16::Prover<AltBn128::Engine>>> provers;
     std::map<std::string, std::unique_ptr<ZKeyUtils::Header>> zkHeaders;
@@ -40,7 +42,7 @@ class FullProver {
 public: 
     FullProver(std::string zkeyFileNames[], int size);
     ~FullProver();
-    void startProve(std::string input);
+    void startProve(std::string input, std::string circuit);
     void abort();
     json getStatus();
     std::string &getErrString() { return errString; };

--- a/src/main_proofserver.cpp
+++ b/src/main_proofserver.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     Routes::Get(router, "/status", Routes::bind(&ProverAPI::getStatus, &proverAPI));
     Routes::Post(router, "/start", Routes::bind(&ProverAPI::postStart, &proverAPI));
     Routes::Post(router, "/stop", Routes::bind(&ProverAPI::postStop, &proverAPI));
-    Routes::Post(router, "/input", Routes::bind(&ProverAPI::postInput, &proverAPI));
+    Routes::Post(router, "/input/:circuit", Routes::bind(&ProverAPI::postInput, &proverAPI));
     Routes::Post(router, "/cancel", Routes::bind(&ProverAPI::postCancel, &proverAPI));
     server.setHandler(router.handler());
     std::string serverReady("Server ready on port " + std::to_string(port) + "...");

--- a/src/main_proofserver.cpp
+++ b/src/main_proofserver.cpp
@@ -1,6 +1,5 @@
 #include <pistache/router.h>
 #include <pistache/endpoint.h>
-
 #include "proverapi.hpp"
 #include "fullprover.hpp"
 #include "logger.hpp"
@@ -10,14 +9,25 @@ using namespace Pistache;
 using namespace Pistache::Rest;
 
 int main(int argc, char **argv) {
+    if (argc < 3) {
+        std::cerr << "Invalid number of parameters:\n";
+        std::cerr << "Usage: proverServer <port> <circuit1.zkey> <circuit2.zkey> ... <circuitN.zkey> \n";
+        return -1;
+    }
 
     Logger::getInstance()->enableConsoleLogging();
     Logger::getInstance()->updateLogLevel(LOG_LEVEL_DEBUG);
     LOG_INFO("Initializing server...");
+    int port = std::stoi(argv[1]); // parse port
+    // parse the zkeys
+    std::string zkeyFileNames[argc - 2];
+    for (int i = 0; i < argc - 2; i++) {
+        zkeyFileNames[i] = argv[i + 2];
+    }
 
-    FullProver fullProver(argv[1], argv[2]);
+    FullProver fullProver(zkeyFileNames, argc - 2);
     ProverAPI proverAPI(fullProver);
-    Address addr(Ipv4::any(), Port(9080));
+    Address addr(Ipv4::any(), Port(port));
 
     auto opts = Http::Endpoint::options().threads(1).maxRequestSize(128000000);
     Http::Endpoint server(addr);
@@ -29,6 +39,7 @@ int main(int argc, char **argv) {
     Routes::Post(router, "/input", Routes::bind(&ProverAPI::postInput, &proverAPI));
     Routes::Post(router, "/cancel", Routes::bind(&ProverAPI::postCancel, &proverAPI));
     server.setHandler(router.handler());
-    LOG_INFO("Server ready on port 9080...");
+    std::string serverReady("Server ready on port " + std::to_string(port) + "...");
+    LOG_INFO(serverReady);
     server.serve();
 }

--- a/src/main_prover.cpp
+++ b/src/main_prover.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
 
     if (argc != 5) {
         std::cerr << "Invalid number of parameters:\n";
-        std::cerr << "Usage: prove <circuit.zkey> <witness.wtns> <proof.json> <public.json>\n";
+        std::cerr << "Usage: prover <circuit.zkey> <witness.wtns> <proof.json> <public.json>\n";
         return -1;
     }
 

--- a/src/proverapi.cpp
+++ b/src/proverapi.cpp
@@ -7,7 +7,9 @@ using json = nlohmann::json;
 
 
 void ProverAPI::postInput(const Rest::Request& request, Http::ResponseWriter response) {
-    fullProver.startProve(request.body());
+    std::string circuit(request.param(":circuit").as<std::string>());
+    LOG_TRACE(circuit);
+    fullProver.startProve(request.body(), circuit);
     response.send(Http::Code::Ok);
 }
 

--- a/tasksfile.js
+++ b/tasksfile.js
@@ -23,7 +23,7 @@ function createFieldSources() {
     } else throw("Unsupported platform");
 }
 
-function buildPistche() {
+function buildPistache() {
     sh("git submodule init && git submodule update");
     sh("mkdir -p build", {cwd: "depends/pistache"});
     sh("cmake -G \"Unix Makefiles\" -DCMAKE_BUILD_TYPE=Release ..", {cwd: "depends/pistache/build"});
@@ -88,7 +88,7 @@ function buildProver() {
 cli({
     cleanAll,
     createFieldSources,
-    buildPistche,
+    buildPistache,
     buildProverServer,
     buildProver
 });

--- a/tasksfile.js
+++ b/tasksfile.js
@@ -32,22 +32,19 @@ function buildPistche() {
 
 
 function buildProverServer() {
-    sh("cp " + process.argv[3] + " build/circuit.cpp", {cwd: ".", nopipe: true});
     sh("g++" +
         " -I."+
         " -I../src"+
         " -I../depends/pistache/include"+
         " -I../depends/json/single_include"+
         " -I../depends/ffiasm/c"+
-        " -I../depends/circom_runtime/c"+
         " ../src/main_proofserver.cpp"+
         " ../src/proverapi.cpp"+
         " ../src/fullprover.cpp"+
         " ../src/binfile_utils.cpp"+
+        " ../src/wtns_utils.cpp"+
         " ../src/zkey_utils.cpp"+
         " ../src/logger.cpp"+
-        " ../depends/circom_runtime/c/calcwit.cpp"+
-        " ../depends/circom_runtime/c/utils.cpp"+
         " ../depends/ffiasm/c/misc.cpp"+
         " ../depends/ffiasm/c/naf.cpp"+
         " ../depends/ffiasm/c/splitparstr.cpp"+
@@ -56,7 +53,6 @@ function buildProverServer() {
         " fq.o"+
         " fr.cpp"+
         " fr.o"+
-        " circuit.cpp"+
         " -L../depends/pistache/build/src -lpistache"+
         " -o proverServer"+
         " -fmax-errors=5 -pthread -std=c++17 -fopenmp -lgmp -lsodium -g -DSANITY_CHECK", {cwd: "build", nopipe: true}

--- a/tools/request.js
+++ b/tools/request.js
@@ -2,9 +2,10 @@ const fs = require("fs");
 const fetch = require('node-fetch');
 
 const input = fs.readFileSync(process.argv[2], "utf8");
+const circuit = process.argv[3];
 
 async function callInput() {
-    const rawResponse = await fetch('http://localhost:9080/input', {
+    const rawResponse = await fetch(`http://localhost:9080/input/${circuit}`, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',


### PR DESCRIPTION
- Fix prover server that was outdated and was not working
- Update pistache submodule to last version for some fixes
- Prover server now can generate proofs for different circuits with the proper configuration.

## Build the server
```
npm install
git submodule init
git submodule update
npx task createFieldSources
npx task buildPistache
npx task buildProverServer
```
## Launch prover in server mode
```
./build/proverServer  <port> <circuit1_zkey> <circuit2_zkey> ... <circuitN_zkey>
```
For every `circuit.circom` you have to generate with circom with --c option the `circuit_cpp` and after compilation you have to copy the executable into the `build` folder so the server can generate the witness and then the proof based on this witness.
The name of the executable should be the name of the circuit directly.
You have an example of the usage calling the server endpoints to generate the proof with Nodejs in `/tools/request.js`.

To test a request you should pass an `input.json` as a parameter to the request call.
```
node tools/request.js <input.json> <circuit>
```

Future improvements. Calculate witness in memory and pass it to the prover.