### PR TITLE
fix(binfile_utils,logger): Enable compilation on macOS

### DIFF
--- a/src/binfile_utils.cpp
+++ b/src/binfile_utils.cpp
@@ -9,6 +9,16 @@
 
 #include "binfile_utils.hpp"
 
+#if __linux__
+#define _MAP_POPULATE_AVAILABLE
+#endif
+
+#ifdef _MAP_POPULATE_AVAILABLE
+#define MMAP_FLAGS (MAP_PRIVATE | MAP_POPULATE)
+#else
+#define MMAP_FLAGS (MAP_PRIVATE)
+#endif
+
 namespace BinFileUtils {
 
 BinFile::BinFile(std::string fileName, std::string _type, uint32_t maxVersion) {
@@ -25,7 +35,7 @@ BinFile::BinFile(std::string fileName, std::string _type, uint32_t maxVersion) {
         throw std::system_error(errno, std::generic_category(), "fstat");
 
     size = sb.st_size;
-    void *addrmm = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE | MAP_POPULATE, fd, 0);
+    void *addrmm = mmap(NULL, sb.st_size, PROT_READ, MMAP_FLAGS, fd, 0);
     addr = malloc(sb.st_size);
     memcpy(addr, addrmm, sb.st_size);
     munmap(addrmm, sb.st_size);

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -58,7 +58,7 @@ Logger::Logger()
       printf("Logger::Logger() -- Mutex attribute could not initialize!!\n");
       exit(0);
    }
-   ret = pthread_mutexattr_settype(&m_Attr, PTHREAD_MUTEX_ERRORCHECK_NP);
+   ret = pthread_mutexattr_settype(&m_Attr, PTHREAD_MUTEX_ERRORCHECK);
    if(ret != 0)
    {   
       printf("Logger::Logger() -- Mutex attribute could not set type!!\n");


### PR DESCRIPTION
* `MAP_POPULATE` is a Linux-only flag to `mmap` [[⁰]][0] that allows to reduce the penalty of page faults. It is safe to omit on macOS, since it only acts as a performance optimization - it doesn't otherwise affect the program behaviour.

* In glibc `PTHREAD_MUTEX_ERRORCHECK_NP` is an alias to `PTHREAD_MUTEX_ERRORCHECK` [[¹]][1], which is also available on macOS [[²]][2].
  * AFAICS, in musl libc `PTHREAD_MUTEX_ERRORCHECK_NP` does not exist and there's only `PTHREAD_MUTEX_ERRORCHECK` [[³]][3]

[0]: https://man7.org/linux/man-pages/man2/mmap.2.html
[1]: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/nptl/pthread.h;h=3d0d07ceb2dbf5d19dcdf5cbb0320eb658d71578;hb=a704fd9a133bfb10510e18702f48a6a9c88dbbd5#l57
[2]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/pthread_mutexattr_settype.3.html
[3]: https://git.musl-libc.org/cgit/musl/tree/include/pthread.h?h=v1.2.3#n39