### PR TITLE
Optimizing Lagrange calculation

### DIFF
--- a/src/fflonk_prover.c.hpp
+++ b/src/fflonk_prover.c.hpp
@@ -1569,26 +1569,11 @@ namespace Fflonk
         //     toInverse.yBatch -> Computed in round5, computeL()
 
         //   · denominator needed in the verifier when computing L_i^{S0}(X), L_i^{S1}(X) and L_i^{S2}(X)
-        for (uint i = 0; i < 8; i++)
-        {
-            ss.str("");
-            ss << "LiS0_" << (i + 1);
-            toInverse[ss.str()] = computeLiS0(i);
-        }
+        computeLiS0();
 
-        for (uint i = 0; i < 4; i++)
-        {
-            ss.str("");
-            ss << "LiS1_" << (i + 1);
-            toInverse[ss.str()] = computeLiS1(i);
-        }
+        computeLiS1();
 
-        for (uint i = 0; i < 6; i++)
-        {
-            ss.str("");
-            ss << "LiS2_" << (i + 1);
-            toInverse[ss.str()] = computeLiS2(i);
-        }
+        computeLiS2();
 
         //   · L_i i=1 to num public inputs, needed in step 6 and 7 of the verifier to compute L_1(xi) and PI(xi)
         u_int32_t size = std::max(1, (int)zkey->nPublic);
@@ -1599,8 +1584,6 @@ namespace Fflonk
             ss.str("");
             ss << "Li_" << (i + 1);
             toInverse[ss.str()] = E.fr.mul(E.fr.set(zkey->domainSize), E.fr.sub(challenges["xi"], w));
-
-            // w = E.fr.mul(w, zkey->w);
         }
 
         FrElement mulAccumulator = E.fr.one();
@@ -1614,50 +1597,74 @@ namespace Fflonk
     }
 
     template <typename Engine>
-    typename Engine::FrElement FflonkProver<Engine>::computeLiS0(u_int32_t i)
-    {
+    void FflonkProver<Engine>::computeLiS0()
+    {    
+        std::ostringstream ss;
+
+        FrElement den1 = E.fr.set(8);
+        for (u_int64_t i = 0; i < 6; i++)
+        {
+            den1 = E.fr.mul(den1, roots["S0h0"][0]);
+        }
+
         // Compute L_i^{(S0)}(y)
-        u_int32_t idx = i;
-        FrElement den = E.fr.one();
-        for (uint j = 0; j < 7; j++)
-        {
-            idx = (idx + 1) % 8;
+        for (uint j = 0; j < 8; j++) {
 
-            den = E.fr.mul(den, E.fr.sub(roots["S0h0"][i], roots["S0h0"][idx]));
+            FrElement den2 = roots["S0h0"][(7 * j) % 8];
+            FrElement den3 = E.fr.sub(challenges["y"], roots["S0h0"][j]);
+
+            ss.str("");
+            ss << "LiS0_" << (j + 1) << " ";
+            toInverse[ss.str()] = E.fr.mul(E.fr.mul(den1, den2), den3);
         }
-        return den;
+        return;
     }
 
     template <typename Engine>
-    typename Engine::FrElement FflonkProver<Engine>::computeLiS1(u_int32_t i)
-    {
-        // Compute L_i^{(S1)}(y)
-        u_int32_t idx = i;
-        FrElement den = E.fr.one();
-        for (uint j = 0; j < 3; j++)
-        {
-            idx = (idx + 1) % 4;
+    void FflonkProver<Engine>::computeLiS1()
+    {    
+        std::ostringstream ss;
 
-            den = E.fr.mul(den, E.fr.sub(roots["S1h1"][i], roots["S1h1"][idx]));
+        // Compute L_i^{(S1)}(y)
+        FrElement den1 = E.fr.mul(E.fr.set(4), E.fr.mul(roots["S1h1"][0], roots["S1h1"][0]));
+        for (uint j = 0; j < 4; j++) {
+
+            FrElement den2 = roots["S1h1"][(3 * j) % 4];
+            FrElement den3 = E.fr.sub(challenges["y"], roots["S1h1"][j]);
+
+            ss.str("");
+            ss << "LiS1_" << (j + 1) << " ";
+            toInverse[ss.str()] = E.fr.mul(E.fr.mul(den1, den2), den3);
         }
-        return den;
+        return;
     }
-
+    
     template <typename Engine>
-    typename Engine::FrElement FflonkProver<Engine>::computeLiS2(u_int32_t i)
-    {
-        // Compute L_i^{(S1)}(y)
-        u_int32_t idx = i;
-        FrElement den = E.fr.one();
-        for (uint j = 0; j < 5; j++)
-        {
-            idx = (idx + 1) % 6;
+    void FflonkProver<Engine>::computeLiS2()
+    {    
+        std::ostringstream ss;
 
-            FrElement root1 = i < 3 ? roots["S2h2"][i] : roots["S2h3"][i - 3];
-            FrElement root2 = idx < 3 ? roots["S2h2"][idx] : roots["S2h3"][idx - 3];
-            den = E.fr.mul(den, E.fr.sub(root1, root2));
+        // Compute L_i^{(S2)}(y)
+        FrElement den1 = E.fr.mul(E.fr.mul(E.fr.set(3), roots["S2h2"][0]), E.fr.sub(challenges["xi"], challenges["xiw"]));
+        for (uint j = 0; j < 3; j++) {
+            FrElement den2 = roots["S2h2"][2*j % 3];
+            FrElement den3 = E.fr.sub(challenges["y"], roots["S2h2"][j]);
+             
+            ss.str("");
+            ss << "LiS2_" << (j + 1) << " ";
+            toInverse[ss.str()] = E.fr.mul(E.fr.mul(den1, den2), den3);
         }
-        return den;
+
+        den1 = E.fr.mul(E.fr.mul(E.fr.set(3), roots["S2h3"][0]), E.fr.sub(challenges["xiw"], challenges["xi"]));
+        for (uint j = 0; j < 3; j++) {
+            FrElement den2 = roots["S2h3"][2*j % 3];
+            FrElement den3 = E.fr.sub(challenges["y"], roots["S2h3"][j]);
+             
+            ss.str("");
+            ss << "LiS2_" << (j + 1 + 3) << " ";
+            toInverse[ss.str()] = E.fr.mul(E.fr.mul(den1, den2), den3);
+        }
+        return;
     }
 
     template <typename Engine>

--- a/src/fflonk_prover.c.hpp
+++ b/src/fflonk_prover.c.hpp
@@ -1584,6 +1584,7 @@ namespace Fflonk
             ss.str("");
             ss << "Li_" << (i + 1);
             toInverse[ss.str()] = E.fr.mul(E.fr.set(zkey->domainSize), E.fr.sub(challenges["xi"], w));
+            w = E.fr.mul(w, fft->root(zkeyPower, 1));
         }
 
         FrElement mulAccumulator = E.fr.one();

--- a/src/fflonk_prover.hpp
+++ b/src/fflonk_prover.hpp
@@ -148,11 +148,11 @@ namespace Fflonk {
 
         FrElement getMontgomeryBatchedInverse();
 
-        FrElement computeLiS0(u_int32_t i);
+        void computeLiS0();
 
-        FrElement computeLiS1(u_int32_t i);
+        void computeLiS1();
 
-        FrElement computeLiS2(u_int32_t i);
+        void computeLiS2();
 
         G1Point multiExponentiation(Polynomial<Engine> *polynomial);
 

--- a/src/keccak_256_transcript.c.hpp
+++ b/src/keccak_256_transcript.c.hpp
@@ -43,7 +43,7 @@ typename Engine::FrElement Keccak256Transcript<Engine>::getChallenge() {
             bytes += E.fr.toRprBE(element, data + bytes, E.fr.bytes());
         } else {
             G1Point element = std::any_cast<G1Point>(elements[i].element);
-            bytes += toRprBE(element, data, bytes, sizeof(element));
+            bytes += toRprBE(element, data, bytes, E.g1.F.bytes());
         }
     }
 


### PR DESCRIPTION
This PR modifies the way the prover calculates the batch inverse so that it works with Lagrange polynomials being calculated using the formula in the verifier SC. 

This modification is also being merged in `snarkjs` in the following PR: https://github.com/iden3/snarkjs/pull/368

This PR also fixes fflonk prover so that it works properly with multiple public inputs:
- Lagrange polynomials for public inputs are properly calculated if there's more than 1 public input.
- Keccak transcript call to function `toRprBE` is modified for G1 points, and the Fr.bytes() is sent as size instead of sizeof(element). 